### PR TITLE
simple fix

### DIFF
--- a/src/core/tn_mutex.c
+++ b/src/core/tn_mutex.c
@@ -617,6 +617,7 @@ static void _mutex_do_unlock(struct TN_Mutex * mutex)
  */
 static void _update_holders_priority_recursive(struct TN_Task *task)
 {
+   struct TN_Task *original = task;
    struct TN_Task *holder;
 
 in:
@@ -626,6 +627,11 @@ in:
    //   already release it. In either case, `mutex->holder` still
    //   points to the task which is/was holding the mutex.
    holder = _get_mutex_by_wait_queque(task->pwait_queue)->holder;
+
+   //-- check for infinite recursion and exit if loop is detected
+   if (holder == original) {
+      return;
+   }
 
    //-- now, `holder` points to the (ex-)holder, i.e. to the task which is/was
    //   holding the mutex. Now, we iterate through all the mutexes that are


### PR DESCRIPTION
Basic recursion stopper by noting the original task, and exiting if the recursion returns back to that value.