### PR TITLE
Fix type for 'sr' variables

### DIFF
--- a/src/core/tn_dqueue.c
+++ b/src/core/tn_dqueue.c
@@ -764,7 +764,7 @@ enum TN_RCode tn_queue_eventgrp_connect(
       TN_UWord             pattern
       )
 {
-   int sr_saved;
+   TN_UWord sr_saved;
    enum TN_RCode rc = _check_param_generic(dque);
 
    if (rc == TN_RC_OK){
@@ -783,7 +783,7 @@ enum TN_RCode tn_queue_eventgrp_disconnect(
       struct TN_DQueue    *dque
       )
 {
-   int sr_saved;
+   TN_UWord sr_saved;
    enum TN_RCode rc = _check_param_generic(dque);
 
    if (rc == TN_RC_OK){

--- a/src/core/tn_timer.c
+++ b/src/core/tn_timer.c
@@ -139,7 +139,7 @@ enum TN_RCode tn_timer_create(
  */
 enum TN_RCode tn_timer_delete(struct TN_Timer *timer)
 {
-   int sr_saved;
+   TN_UWord sr_saved;
    enum TN_RCode rc = _check_param_generic(timer);
 
    if (rc == TN_RC_OK){
@@ -160,7 +160,7 @@ enum TN_RCode tn_timer_delete(struct TN_Timer *timer)
  */
 enum TN_RCode tn_timer_start(struct TN_Timer *timer, TN_TickCnt timeout)
 {
-   int sr_saved;
+   TN_UWord sr_saved;
    enum TN_RCode rc = _check_param_generic(timer);
 
    if (rc == TN_RC_OK){
@@ -177,7 +177,7 @@ enum TN_RCode tn_timer_start(struct TN_Timer *timer, TN_TickCnt timeout)
  */
 enum TN_RCode tn_timer_cancel(struct TN_Timer *timer)
 {
-   int sr_saved;
+   TN_UWord sr_saved;
    enum TN_RCode rc = _check_param_generic(timer);
 
    if (rc == TN_RC_OK){
@@ -198,7 +198,7 @@ enum TN_RCode tn_timer_set_func(
       void             *p_user_data
       )
 {
-   int sr_saved;
+   TN_UWord sr_saved;
    enum TN_RCode rc = _check_param_generic(timer);
 
    if (rc == TN_RC_OK){
@@ -215,7 +215,7 @@ enum TN_RCode tn_timer_set_func(
  */
 enum TN_RCode tn_timer_is_active(struct TN_Timer *timer, TN_BOOL *p_is_active)
 {
-   int sr_saved;
+   TN_UWord sr_saved;
    enum TN_RCode rc = _check_param_generic(timer);
 
    if (rc == TN_RC_OK){
@@ -235,7 +235,7 @@ enum TN_RCode tn_timer_time_left(
       TN_TickCnt *p_time_left
       )
 {
-   int sr_saved;
+   TN_UWord sr_saved;
    enum TN_RCode rc = _check_param_generic(timer);
 
    if (rc == TN_RC_OK){


### PR DESCRIPTION
- tn_arch_sr_save_int_dis() returns a 'TN_UWord' and not a 'int' value.
- Issue found trying to compile for a 64-bit core where 'unsigned long int' (TN_UWord) and 'int' have different size.