### PR TITLE
Update tn_arch_cortex_m.S (_tn_arch_context_switch_pend)

### DIFF
--- a/src/arch/cortex_m/tn_arch_cortex_m.S
+++ b/src/arch/cortex_m/tn_arch_cortex_m.S
@@ -584,7 +584,10 @@ _TN_LABEL(_tn_arch_context_switch_pend)
       ldr      r1, =ICSR_ADDR
       ldr      r0, =PENDSVSET
       str      r0, [r1]
-
+#if defined(__TN_ARCHFEAT_CORTEX_M_ARMv7M_ISA__)
+      dsb      //Sometimes interrupt doesn't fires immediately on cortex-m7, 
+      isb      //so we need to set those barriers here
+#endif
       bx       lr
 
 


### PR DESCRIPTION
Sometimes PendSV interrupt doesn't fires immediately after setting PENDSVSET bit on cortex-m7. It cause problems in tn_eventgrp_wait function because it reaches "rc = _tn_curr_run_task->task_wait_rc;" line before PendSV interrupt fires and we get incorrect wait result.